### PR TITLE
20122023

### DIFF
--- a/20122023 v0.1
+++ b/20122023 v0.1
@@ -1,0 +1,9 @@
+EMUWII version 0.1
+Emulators in pack:
+ • Yabause - Sega saturn
+ • WiiSXR - Playstation 1 
+ • Wiimednafen - Game Boy / Advance, Game Gear, NES, PC Engine, PC-FX, SuperGrafx, WonderSwan, Virtual Boy,Neo Geo Pocket,(Вроде Atari) Lynx, Mega Drive, Master System.
+ • sdlmamewii - MAME
+ • Nintendont - GameCube
+ • not64 - Super Nintendo 64
+ • DeSmuMEWii - Nintendo DS


### PR DESCRIPTION
EMUWII version 0.1
Emulators in pack:
 • Yabause - Sega saturn
 • WiiSXR - Playstation 1 
 • Wiimednafen - Game Boy / Advance, Game Gear, NES, PC Engine, PC-FX, SuperGrafx, WonderSwan, Virtual Boy,Neo Geo Pocket,(Вроде Atari) Lynx, Mega Drive, Master System.
 • sdlmamewii - MAME
 • Nintendont - GameCube
 • not64 - Super Nintendo 64
 • DeSmuMEWii - Nintendo DS